### PR TITLE
pino: flat log.level, use "name" for log.logger

### DIFF
--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -1,8 +1,15 @@
-# Changelog
+# @elastic/ecs-morgan-format Changelog
+
+## v0.3.0
+
+- Serialize "log.level" as a top-level dotted field per
+  <https://github.com/elastic/ecs-logging/pull/33> -
+  [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.0
+
 - Use the version number provided by ecs-helpers - [#13](https://github.com/elastic/ecs-logging-js/pull/13)
 
-
 ## v0.1.0
+
 Initial release.

--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.3.0
 
 - Serialize "log.level" as a top-level dotted field per
-  <https://github.com/elastic/ecs-logging/pull/33> -
+  https://github.com/elastic/ecs-logging/pull/33.
   [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.0

--- a/loggers/morgan/index.js
+++ b/loggers/morgan/index.js
@@ -19,10 +19,7 @@ function ecsFormat (format = morgan.combined) {
   function formatter (token, req, res) {
     var ecs = {
       '@timestamp': new Date().toISOString(),
-      log: {
-        level: res.statusCode < 500 ? 'info' : 'error',
-        logger: 'morgan'
-      },
+      'log.level': res.statusCode < 500 ? 'info' : 'error',
       message: messageFormat(token, req, res),
       ecs: { version }
     }

--- a/loggers/morgan/package.json
+++ b/loggers/morgan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-morgan-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A formatter for the morgan logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "repository": {
@@ -31,7 +31,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^0.2.0"
+    "@elastic/ecs-helpers": "^0.3.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",

--- a/loggers/morgan/test.js
+++ b/loggers/morgan/test.js
@@ -59,7 +59,7 @@ test.cb('Keys order', t => {
 
   const stream = split().on('data', line => {
     const log = JSON.parse(line)
-    t.is(line, `{"@timestamp":"${log['@timestamp']}","log":{"level":"info","logger":"morgan"},"message":"${JSON.stringify(log.message).slice(1, -1)}","ecs":{"version":"${version}"},"http":{"version":"1.1","request":{"method":"post","headers":{"accept-encoding":"gzip, deflate","content-type":"application/json","host":"${log.http.request.headers.host}","connection":"close"},"body":{"bytes":17}},"response":{"status_code":200,"headers":{"x-powered-by":"Express"}}},"url":{"path":"/","domain":"localhost","query":"foo=bar","full":"http://localhost:${server.address().port}/?foo=bar"},"user_agent":{"original":"cool-agent"}}`)
+    t.is(line, `{"@timestamp":"${log['@timestamp']}","log.level":"info","message":"${JSON.stringify(log.message).slice(1, -1)}","ecs":{"version":"${version}"},"http":{"version":"1.1","request":{"method":"post","headers":{"accept-encoding":"gzip, deflate","content-type":"application/json","host":"${log.http.request.headers.host}","connection":"close"},"body":{"bytes":17}},"response":{"status_code":200,"headers":{"x-powered-by":"Express"}}},"url":{"path":"/","domain":"localhost","query":"foo=bar","full":"http://localhost:${server.address().port}/?foo=bar"},"user_agent":{"original":"cool-agent"}}`)
   })
 
   const app = express()

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -1,4 +1,13 @@
-# Changelog
+# @elastic/ecs-pino-format Changelog
+
+## v0.2.0
+
+- Serialize "log.level" as a top-level dotted field per
+  <https://github.com/elastic/ecs-logging/pull/33>.
+  Set ["log.logger"](https://www.elastic.co/guide/en/ecs/current/ecs-log.html#field-log-logger)
+  to the logger ["name"](https://getpino.io/#/docs/api?id=name-string) if given.
+  ([#23](https://github.com/elastic/ecs-logging-js/pull/23))
 
 ## v0.1.0
+
 Initial release.

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.2.0
 
 - Serialize "log.level" as a top-level dotted field per
-  <https://github.com/elastic/ecs-logging/pull/33>.
-  Set ["log.logger"](https://www.elastic.co/guide/en/ecs/current/ecs-log.html#field-log-logger)
+  https://github.com/elastic/ecs-logging/pull/33 and
+  set ["log.logger"](https://www.elastic.co/guide/en/ecs/current/ecs-log.html#field-log-logger)
   to the logger ["name"](https://getpino.io/#/docs/api?id=name-string) if given.
   ([#23](https://github.com/elastic/ecs-logging-js/pull/23))
 

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-pino-format",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "repository": {

--- a/loggers/pino/test.js
+++ b/loggers/pino/test.js
@@ -24,11 +24,23 @@ test('Should produce valid ecs logs', t => {
   t.plan(2)
 
   const stream = split(JSON.parse).on('data', line => {
-    t.deepEqual(line.log, { level: 'info', logger: 'pino' })
+    t.deepEqual(line['log.level'], 'info')
     t.true(validate(line))
   })
 
   const pino = Pino({ ...ecsFormat() }, stream)
+  pino.info('Hello world')
+})
+
+test('Should map "name" to "log.logger"', t => {
+  t.plan(2)
+
+  const stream = split(JSON.parse).on('data', line => {
+    t.deepEqual(line.log, { logger: 'myName' })
+    t.true(validate(line))
+  })
+
+  const pino = Pino({ name: 'myName', ...ecsFormat() }, stream)
   pino.info('Hello world')
 })
 

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -1,7 +1,15 @@
-# Changelog
+# elastic/ecs-winston-format Changelog
+
+## v0.3.0
+
+- Serialize "log.level" as a top-level dotted field per
+  <https://github.com/elastic/ecs-logging/pull/33> -
+  [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.0
+
 - Use the version number provided by ecs-helpers - [#13](https://github.com/elastic/ecs-logging-js/pull/13)
 
 ## v0.1.0
+
 Initial release.

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.3.0
 
 - Serialize "log.level" as a top-level dotted field per
-  <https://github.com/elastic/ecs-logging/pull/33> -
+  https://github.com/elastic/ecs-logging/pull/33.
   [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.0

--- a/loggers/winston/index.js
+++ b/loggers/winston/index.js
@@ -28,10 +28,7 @@ const reservedKeys = [
 function ecsFormat (log) {
   var ecs = {
     '@timestamp': new Date().toISOString(),
-    log: {
-      level: log.level,
-      logger: 'winston'
-    },
+    'log.level': log.level,
     message: log.message,
     ecs: { version }
   }

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "repository": {
@@ -30,7 +30,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^0.2.0"
+    "@elastic/ecs-helpers": "^0.3.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",

--- a/loggers/winston/test.js
+++ b/loggers/winston/test.js
@@ -50,7 +50,7 @@ test('Bad ecs log (on purpose)', t => {
   class TestTransport extends Transport {
     log (info, callback) {
       const line = JSON.parse(info[MESSAGE])
-      line.log.level = true
+      line['@timestamp'] = true
       t.false(validate(line))
       callback()
     }
@@ -92,7 +92,7 @@ test('Should not change the log level', t => {
   class TestTransport extends Transport {
     log (info, callback) {
       const line = JSON.parse(info[MESSAGE])
-      t.is(line.log.level, 'error')
+      t.is(line['log.level'], 'error')
       callback()
     }
   }
@@ -225,12 +225,12 @@ test('Keys order', t => {
       if (count++ === 0) {
         t.is(
           info[MESSAGE],
-          `{"@timestamp":"${line['@timestamp']}","log":{"level":"info","logger":"winston"},"message":"ecs is cool!","ecs":{"version":"${version}"}}`
+          `{"@timestamp":"${line['@timestamp']}","log.level":"info","message":"ecs is cool!","ecs":{"version":"${version}"}}`
         )
       } else {
         t.is(
           info[MESSAGE],
-          `{"@timestamp":"${line['@timestamp']}","log":{"level":"error","logger":"winston"},"message":"ecs is cool!","ecs":{"version":"${version}"},"hello":"world"}`
+          `{"@timestamp":"${line['@timestamp']}","log.level":"error","message":"ecs is cool!","ecs":{"version":"${version}"},"hello":"world"}`
         )
       }
       callback()


### PR DESCRIPTION
Per https://github.com/elastic/ecs-logging/blob/c3567a9/spec/spec.json#L21 it
is preferred to have "log.level" as a flat top-level field.

Also, the intent of log.logger is to be the app's logger name, rather
than the name of the logging framework.