### PR TITLE
helpers: stringify() 'log.level' as a top-level dotted field

### DIFF
--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Changelog
+# @elastic/ecs-helpers Changelog
+
+## v0.3.0
+
+- Change `stringify()` to serialize "log.level" as a top-level dotted field
+  per <https://github.com/elastic/ecs-logging/pull/33> -
+  [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.1
 

--- a/helpers/package.json
+++ b/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-helpers",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "ECS loggers helpers",
   "main": "index.js",
   "repository": {

--- a/helpers/serializer.js
+++ b/helpers/serializer.js
@@ -13,10 +13,10 @@ const stringify = build({
   type: 'object',
   properties: {
     '@timestamp': string,
+    'log.level': string,
     log: {
       type: 'object',
       properties: {
-        level: string,
         logger: string
       }
     },


### PR DESCRIPTION
per https://github.com/elastic/ecs-logging/pull/33

I need to get this in and publish a new helpers package before completing https://github.com/elastic/ecs-logging-js/pull/23