### PR TITLE
helpers: stringify() 'log.level' as a top-level dotted field

### DIFF
--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Changelog
+# @elastic/ecs-helpers Changelog
+
+## v0.3.0
+
+- Change `stringify()` to serialize "log.level" as a top-level dotted field
+  per <https://github.com/elastic/ecs-logging/pull/33> -
+  [#23](https://github.com/elastic/ecs-logging-js/pull/23)
 
 ## v0.2.1
 

--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.3.0
 
 - Change `stringify()` to serialize "log.level" as a top-level dotted field
-  per <https://github.com/elastic/ecs-logging/pull/33> -
-  [#23](https://github.com/elastic/ecs-logging-js/pull/23)
+  per <https://github.com/elastic/ecs-logging/pull/33>.
+  ([#25](https://github.com/elastic/ecs-logging-js/pull/25))
 
 ## v0.2.1
 

--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Change `stringify()` to serialize "log.level" as a top-level dotted field
   per <https://github.com/elastic/ecs-logging/pull/33>.
-  ([#25](https://github.com/elastic/ecs-logging-js/pull/25))
+  ([#27](https://github.com/elastic/ecs-logging-js/pull/27))
 
 ## v0.2.1
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-nodejs%2Fecs-logging-js-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/ecs-logging-js-mbp/job/master/)  [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 
-A set of helpers for the ECS logging libraries.  
+A set of helpers for the ECS logging libraries.
 You should not directly used this package, but the ECS logging libraries instead.
 
 ## Install
@@ -15,20 +15,20 @@ npm i @elastic/ecs-helpers
 ## API
 
 ### `version`
-The currently supported version of [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html),
+The currently supported version of [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html).
 
 ### `stringify`
-Function that serializes (very quickly!) an ECS object.
+Function that serializes (very quickly!) an ECS-format log record object.
 
 ```js
 const { stringify } = require('@elastic/ecs-helpers')
 const ecs = {
   '@timestamp': new Date().toISOString(),
+  'log.level': 'info',
+  message: 'hello world',
   log: {
-    level: 'info',
     logger: 'test'
   },
-  message: 'hello world',
   ecs: {
     version: '1.4.0'
   }
@@ -45,11 +45,11 @@ The request object should be Node.js's core request object.
 const { formatHttpRequest } = require('@elastic/ecs-helpers')
 const ecs = {
   '@timestamp': new Date().toISOString(),
+  'log.level': 'info',
+  message: 'hello world',
   log: {
-    level: 'info',
     logger: 'test'
   },
-  message: 'hello world',
   ecs: {
     version: '1.4.0'
   }
@@ -67,11 +67,11 @@ The response object should be Node.js's core response object.
 const { formatHttpResponse } = require('@elastic/ecs-helpers')
 const ecs = {
   '@timestamp': new Date().toISOString(),
+  'log.level': 'info',
+  message: 'hello world',
   log: {
-    level: 'info',
     logger: 'test'
   },
-  message: 'hello world',
   ecs: {
     version: '1.4.0'
   }

--- a/helpers/package.json
+++ b/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-helpers",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "ECS loggers helpers",
   "main": "index.js",
   "repository": {

--- a/helpers/serializer.js
+++ b/helpers/serializer.js
@@ -13,10 +13,10 @@ const stringify = build({
   type: 'object',
   properties: {
     '@timestamp': string,
+    'log.level': string,
     log: {
       type: 'object',
       properties: {
-        level: string,
         logger: string
       }
     },

--- a/helpers/test.js
+++ b/helpers/test.js
@@ -27,10 +27,7 @@ const validate = ajv.compile(require('../utils/schema.json'))
 test('Stringify should return a valid ecs json', t => {
   const ecs = {
     '@timestamp': new Date().toISOString(),
-    log: {
-      level: 'info',
-      logger: 'test'
-    },
+    'log.level': 'info',
     message: 'hello world',
     ecs: {
       version: '1.4.0'
@@ -44,10 +41,7 @@ test('Stringify should return a valid ecs json', t => {
 test('Bad ecs json (on purpose)', t => {
   const ecs = {
     '@timestamp': 'not a date',
-    log: {
-      level: 'info',
-      logger: 'test'
-    },
+    'log.level': 'info',
     message: true,
     ecs: {
       version: '1.4.0'
@@ -81,10 +75,7 @@ test.cb('formatHttpRequest and formatHttpResponse should returna valid ecs objec
   function handler (req, res) {
     const ecs = {
       '@timestamp': new Date().toISOString(),
-      log: {
-        level: 'info',
-        logger: 'test'
-      },
+      'log.level': 'info',
       message: 'hello world',
       ecs: {
         version: '1.4.0'


### PR DESCRIPTION
per elastic/ecs-logging#33

I need to get this in and publish a new helpers package before completing #23