### PR TITLE
pino: add 'ecs.version' field in bindings to not have to specify for each log

### DIFF
--- a/loggers/pino/index.js
+++ b/loggers/pino/index.js
@@ -36,6 +36,9 @@ function build () {
         } = bindings
 
         const ecsBindings = {
+          ecs: {
+            version
+          },
           process: {
             pid: pid
           },
@@ -58,8 +61,6 @@ function build () {
           response,
           ...ecs
         } = obj
-
-        ecs.ecs = { version }
 
         if (req || request) {
           formatHttpRequest(ecs, req || request)

--- a/loggers/pino/test.js
+++ b/loggers/pino/test.js
@@ -20,12 +20,13 @@ const ajv = Ajv({
 })
 const validate = ajv.compile(require('../../utils/schema.json'))
 
-test('Should produce valid ecs logs', t => {
-  t.plan(2)
-
+test.cb('Should produce valid ecs logs', t => {
   const stream = split(JSON.parse).on('data', line => {
     t.deepEqual(line['log.level'], 'info')
+    t.assert(line.ecs, 'has "ecs" field')
+    t.assert(line.ecs.version, 'has "ecs.version" field')
     t.true(validate(line))
+    t.end()
   })
 
   const pino = Pino({ ...ecsFormat() }, stream)


### PR DESCRIPTION
`bindings()` is called once at Logger instance creation; `log()` is called for each `<logger>.info()` call. While this is premature optimization, it is possibly slightly faster to set this in bindings.