### PR TITLE
winston: change from ava to tap for testing

### DIFF
--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -4,7 +4,7 @@
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [
-      "index.js"
+    "index.js"
   ],
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/elastic/ecs-logging-js/blob/master/loggers/winston/README.md",
   "scripts": {
-    "test": "standard && ava -v"
+    "test": "standard && tap --100"
   },
   "engines": {
     "node": ">=10"
@@ -37,10 +37,10 @@
   },
   "devDependencies": {
     "ajv": "^6.11.0",
-    "ava": "^3.1.0",
     "simple-get": "^3.1.0",
     "standard": "^14.3.1",
     "stoppable": "^1.1.0",
+    "tap": "^14.x",
     "winston": "^3.2.1"
   }
 }


### PR DESCRIPTION
It adds coverage testing (including mandating 100% coverage with the
tap "--100" option). As well, I find that node-tap is slightly more
reliable on identifying a particular failing test when an exception
is raised.

# coverage

```
% npx tap --100
 PASS  test.js 13 OK 74.95ms


  🌈 SUMMARY RESULTS 🌈


Suites:   1 passed, 1 of 1 completed
Asserts:  13 passed, of 13
Time:     1s
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |      100 |      100 |      100 |                   |
 index.js |      100 |      100 |      100 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|
```

# a test failing with an exception

For example, I was working on the ecs-winston-format module and hit an exception in one of the tests:

```
> @elastic/ecs-winston-format@0.3.0 test /Users/trentm/tm/ecs-logging-js/loggers/winston
> standard && ava -v


  ✔ Should produce valid ecs logs
  ✔ Bad ecs log (on purpose)
  ✔ Should not change the message
  ✔ Should not change the log level
  ✔ Should append any additional property to the log message
  ✔ Keys order

  Uncaught exception in test.js

  TypeError: Converting circular structure to JSON

  › JSON.stringify (<anonymous>)
  › $main (eval at build (node_modules/fast-json-stringify/index.js:149:20), <anonymous>:261:51)
  › Format.ecsTransform [as transform] (index.js:52:18)
  › DerivedLogger._transform (node_modules/winston/lib/winston/logger.js:305:29)
  › DerivedLogger.Transform._read (node_modules/readable-stream/lib/_stream_transform.js:177:10)
  › DerivedLogger.Transform._write (node_modules/readable-stream/lib/_stream_transform.js:164:83)
  › doWrite (node_modules/readable-stream/lib/_stream_writable.js:409:139)
  › writeOrBuffer (node_modules/readable-stream/lib/_stream_writable.js:398:5)
  › DerivedLogger.Writable.write (node_modules/readable-stream/lib/_stream_writable.js:307:11)
  › DerivedLogger.log (node_modules/winston/lib/winston/logger.js:244:14)

  ✔ http request and response (req, res keys)
  ✖ test.js exited with a non-zero exit code: 1
  ─

  7 tests passed
  1 uncaught exception
npm ERR! Test failed.  See above for more details.
```

with ava -c1:

```
% ./node_modules/.bin/ava -c 1

  Uncaught exception in test.js

  TypeError: Converting circular structure to JSON

  › JSON.stringify (<anonymous>)
  › $main (eval at build (node_modules/fast-json-stringify/index.js:149:20), <anonymous>:261:51)
  › Format.ecsTransform [as transform] (index.js:52:18)
  › DerivedLogger._transform (node_modules/winston/lib/winston/logger.js:305:29)
  › DerivedLogger.Transform._read (node_modules/readable-stream/lib/_stream_transform.js:177:10)
  › DerivedLogger.Transform._write (node_modules/readable-stream/lib/_stream_transform.js:164:83)
  › doWrite (node_modules/readable-stream/lib/_stream_writable.js:409:139)
  › writeOrBuffer (node_modules/readable-stream/lib/_stream_writable.js:398:5)
  › DerivedLogger.Writable.write (node_modules/readable-stream/lib/_stream_writable.js:307:11)
  › DerivedLogger.log (node_modules/winston/lib/winston/logger.js:244:14)

  ─

  7 tests passed
  1 uncaught exception
```

with tap (after conversion):

```
% npx tap
 FAIL  test.js
 ✖ Converting circular structure to JSON

  test: http request and response (request, response keys)
  stack: >
    JSON.stringify (<anonymous>)

    $main (eval at build (node_modules/fast-json-stringify/index.js:149:20), <anonymous>:261:51)

    Format.ecsFormat (index.js:52:18)

    DerivedLogger._transform (node_modules/winston/lib/winston/logger.js:305:29)

    DerivedLogger.Transform._read (node_modules/readable-stream/lib/_stream_transform.js:177:10)

    DerivedLogger.Transform._write (node_modules/readable-stream/lib/_stream_transform.js:164:83)

    doWrite (node_modules/readable-stream/lib/_stream_writable.js:409:139)

    writeOrBuffer (node_modules/readable-stream/lib/_stream_writable.js:398:5)

    DerivedLogger.Writable.write (node_modules/readable-stream/lib/_stream_writable.js:307:11)

    DerivedLogger.log (node_modules/winston/lib/winston/logger.js:244:14)
  type: TypeError
  tapCaught: uncaughtException

 RUNS  test.js 1 failed of 11 17s
...
Suites:   0 of 1 completed
Asserts:  1 failed, 9 passed, of 11
Time:     30s
...
```

# other comparison notes

Unfortunately node-tap is much bigger:

```
% du -sh node_modules
145M	node_modules
```

vs:

```
% du -sh node_modules
 64M	node_modules
```

Both ava and node-tap do a good job presenting code snippets and diffs on assertion failures.

I like that node-tap test files can be run without the runner. I.e. they are run without a special environment. As well the runner runs them out of process, which can help with multiple test files competing with each other.