### PR TITLE
perf(winston): marginally faster log record building

### DIFF
--- a/loggers/winston/index.js
+++ b/loggers/winston/index.js
@@ -13,15 +13,15 @@ const {
   formatHttpResponse
 } = require('@elastic/ecs-helpers')
 
-const reservedKeys = [
-  'level',
-  'log',
-  'ecs',
-  '@timestamp',
-  'message',
-  'req',
-  'res'
-]
+const reservedFields = {
+  level: true,
+  log: true,
+  ecs: true,
+  '@timestamp': true,
+  message: true,
+  req: true,
+  res: true
+}
 
 // https://github.com/winstonjs/winston#creating-custom-formats
 function ecsTransform (info, opts) {
@@ -50,7 +50,7 @@ function ecsTransform (info, opts) {
   var keys = Object.keys(info)
   for (var i = 0, len = keys.length; i < len; i++) {
     var key = keys[i]
-    if (reservedKeys.indexOf(key) === -1) {
+    if (!reservedFields[key]) {
       ecsFields[key] = info[key]
     }
   }


### PR DESCRIPTION
This changes the Winston transform to use a map lookup rather than array lookup to be slightly faster in theory, and slightly (though marginally and within one stddev -- to the degree I understand the benchmarking tool's reporting):

Before:

```
% npm run bench
...
## Benchmarking server-pong.js

node: v14.15.4
uname: Darwin pink.local 19.6.0 Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64 x86_64
git: heads/master-0-g634210a

Warmup 5s run
Running 30s test @ http://localhost:3000
100 connections with 10 pipelining factor

┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 34 ms │ 39 ms │ 47 ms │ 49 ms │ 39.03 ms │ 3.73 ms │ 104 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬───────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%   │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼───────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 22703   │ 22703   │ 24671 │ 27839   │ 25290.67 │ 1584.21 │ 22700   │
├───────────┼─────────┼─────────┼───────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 3.68 MB │ 3.68 MB │ 4 MB  │ 4.51 MB │ 4.1 MB   │ 257 kB  │ 3.68 MB │
└───────────┴─────────┴─────────┴───────┴─────────┴──────────┴─────────┴─────────┘
```

After (run 1):

```
% npm run bench
...
## Benchmarking server-pong.js

node: v14.15.4
uname: Darwin pink.local 19.6.0 Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64 x86_64
git: heads/master-0-g634210a-dirty

Warmup 5s run
Running 30s test @ http://localhost:3000
100 connections with 10 pipelining factor

┌─────────┬───────┬───────┬───────┬───────┬──────────┬────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev  │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼────────┼────────┤
│ Latency │ 34 ms │ 36 ms │ 42 ms │ 44 ms │ 36.14 ms │ 2.5 ms │ 111 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Req/Sec   │ 24831   │ 24831   │ 27567   │ 28159   │ 27286.4 │ 835.58 │ 24828   │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Bytes/Sec │ 4.02 MB │ 4.02 MB │ 4.47 MB │ 4.56 MB │ 4.42 MB │ 135 kB │ 4.02 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴────────┴─────────┘
```

After (run 2):

```
% npm run bench
...
## Benchmarking server-pong.js

node: v14.15.4
uname: Darwin pink.local 19.6.0 Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64 x86_64
git: heads/master-0-g634210a-dirty

Warmup 5s run
Running 30s test @ http://localhost:3000
100 connections with 10 pipelining factor

┌─────────┬───────┬───────┬───────┬───────┬──────────┬─────────┬────────┐
│ Stat    │ 2.5%  │ 50%   │ 97.5% │ 99%   │ Avg      │ Stdev   │ Max    │
├─────────┼───────┼───────┼───────┼───────┼──────────┼─────────┼────────┤
│ Latency │ 34 ms │ 36 ms │ 44 ms │ 46 ms │ 36.94 ms │ 2.89 ms │ 111 ms │
└─────────┴───────┴───────┴───────┴───────┴──────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 24447   │ 24447   │ 27007   │ 28143   │ 26703.47 │ 1034.74 │ 24439   │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 3.96 MB │ 3.96 MB │ 4.37 MB │ 4.56 MB │ 4.33 MB  │ 168 kB  │ 3.96 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘
```