### PR TITLE
chore: add GH action to auto-label new issues/PRs with 'agent-nodejs'

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -1,0 +1,3 @@
+# add 'agent-nodejs' label to all new issues
+agent-nodejs:
+  - '.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: AlexanderWert/issue-labeler@v2.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler-config.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
This label is used to include issues in the APM Agents project.