### PR TITLE
feat: set "service.name" and "event.dataset" from APM

### DIFF
--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+- Set "service.name" and "event.dataset" log fields if Elastic APM is started.
   This helps to filter for different log streams in the same pod and the
   latter is required for log anomaly detection.
+  ([#41](https://github.com/elastic/ecs-logging-js/issues/41))
 
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)

--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+  This helps to filter for different log streams in the same pod and the
+  latter is required for log anomaly detection.
+
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)
   is in use and there is an active trace, then tracing fields will be added to
   log records. This enables linking between traces and log records in Kibana.
+  ([#35](https://github.com/elastic/ecs-logging-js/issues/35))
 
 - Fix passing of a format *name*, e.g. `app.use(morgan(ecsFormat('tiny')))`.
 

--- a/loggers/morgan/package.json
+++ b/loggers/morgan/package.json
@@ -35,7 +35,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^0.4.0"
+    "@elastic/ecs-helpers": "^0.5.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",

--- a/loggers/morgan/test/apm.test.js
+++ b/loggers/morgan/test/apm.test.js
@@ -115,6 +115,8 @@ test('tracing integration works', t => {
       const tx = traceObjs[1].transaction
       t.equal(logObjs[0].trace.id, tx.trace_id, 'trace.id matches')
       t.equal(logObjs[0].transaction.id, tx.id, 'transaction.id matches')
+      t.equal(logObjs[0].service.name, 'test-apm')
+      t.equal(logObjs[0].event.dataset, 'test-apm.log')
       finish()
     }
   }

--- a/loggers/morgan/test/serve-one-http-req-with-apm.js
+++ b/loggers/morgan/test/serve-one-http-req-with-apm.js
@@ -19,7 +19,7 @@ const serverUrl = process.argv[2]
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
-  serviceName: 'ecs-morgan-format-test-apm',
+  serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
   metricsInterval: 0

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+- Set "service.name" and "event.dataset" log fields if Elastic APM is started.
   This helps to filter for different log streams in the same pod and the
   latter is required for log anomaly detection.
+  ([#41](https://github.com/elastic/ecs-logging-js/issues/41))
 
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+  This helps to filter for different log streams in the same pod and the
+  latter is required for log anomaly detection.
+
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)
   is in use and there is an active trace, then tracing fields will be added to
   log records. This enables linking between traces and log records in Kibana.
+  ([#35](https://github.com/elastic/ecs-logging-js/issues/35))
 
 - BREAKING CHANGE: Conversion of HTTP request and response objects is no longer
   done by default. One must use the new `convertReqRes: true` formatter option.

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -34,7 +34,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^0.2.0"
+    "@elastic/ecs-helpers": "^0.5.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -19,7 +19,7 @@ const serverUrl = process.argv[2]
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
-  serviceName: 'ecs-pino-format-test-apm',
+  serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
   metricsInterval: 0

--- a/loggers/pino/test/use-apm-override-service-name.js
+++ b/loggers/pino/test/use-apm-override-service-name.js
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+// This script is used by "apm.test.js".
+//
+// It will:
+// - use the APM agent (using serviceName from argv[2])
+// - log, setting service.name and event.dataset
+// - log, without setting service.name and event.dataset
+// - flush APM and exit
+
+const serviceName = process.argv[2] || ''
+/* eslint-disable-next-line no-unused-vars */
+const apm = require('elastic-apm-node').start({
+  // Use default serverUrl (fire and forget)
+  serviceName,
+  centralConfig: false,
+  captureExceptions: false,
+  metricsInterval: 0
+})
+
+const ecsFormat = require('../') // @elastic/ecs-pino-format
+const pino = require('pino')
+
+const log = pino({ ...ecsFormat() })
+log.info({
+  foo: 'bar',
+  service: { name: 'myname' },
+  event: { dataset: 'mydataset' }
+}, 'hi')
+log.info({ foo: 'bar' }, 'bye')

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+- Set "service.name" and "event.dataset" log fields if Elastic APM is started.
   This helps to filter for different log streams in the same pod and the
   latter is required for log anomaly detection.
+  ([#41](https://github.com/elastic/ecs-logging-js/issues/41))
 
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+- Set "service.name" and "event.dataset" log fields if Elastic APM is active.
+  This helps to filter for different log streams in the same pod and the
+  latter is required for log anomaly detection.
+
 - Add support for [ECS tracing fields](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html).
   If it is detected that [Elastic APM](https://www.npmjs.com/package/elastic-apm-node)
   is in use and there is an active trace, then tracing fields will be added to
   log records. This enables linking between traces and log records in Kibana.
+  ([#35](https://github.com/elastic/ecs-logging-js/issues/35))
 
 - Fix guarding of the top-level 'log' and 'log.level' fields. A log statement
   can now set ['log' fields](https://www.elastic.co/guide/en/ecs/current/ecs-log.html)

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/elastic/ecs-logging-js/blob/master/loggers/winston/README.md",
   "scripts": {
     "bench": "./benchmarks/bench",
-    "test": "standard && tap --100 --timeout 5 test/*.test.js"
+    "test": "standard && tap --100 --timeout 10 test/*.test.js"
   },
   "engines": {
     "node": ">=10"

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -35,7 +35,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^0.4.0"
+    "@elastic/ecs-helpers": "^0.5.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -19,7 +19,7 @@ const serverUrl = process.argv[2]
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
-  serviceName: 'ecs-winston-format-test-apm',
+  serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
   metricsInterval: 0

--- a/loggers/winston/test/use-apm-override-service-name.js
+++ b/loggers/winston/test/use-apm-override-service-name.js
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+// This script is used by "apm.test.js".
+//
+// It will:
+// - use the APM agent (using serviceName from argv[2])
+// - log, setting service.name and event.dataset
+// - log, without setting service.name and event.dataset
+// - flush APM and exit
+
+const serviceName = process.argv[2] || ''
+require('elastic-apm-node').start({
+  // Use default serverUrl (fire and forget)
+  serviceName,
+  centralConfig: false,
+  captureExceptions: false,
+  metricsInterval: 0
+})
+
+const ecsFormat = require('../') // @elastic/ecs-winston-format
+const winston = require('winston')
+
+const log = winston.createLogger({
+  level: 'info',
+  format: ecsFormat(),
+  transports: [
+    new winston.transports.Console()
+  ]
+})
+
+log.info('hi', {
+  foo: 'bar',
+  service: { name: 'myname' },
+  event: { dataset: 'mydataset' }
+})
+log.info('bye', { foo: 'bar' })


### PR DESCRIPTION
Set "service.name" and "event.dataset" log fields if Elastic APM is started.
This helps to filter for different log streams in the same pod and the
latter is required for log anomaly detection.