### PR TITLE
feat: add helpers.formatError for serializing ECS error fields

### DIFF
--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @elastic/ecs-helpers Changelog
 
+## Unreleased
+
+- Add `formatError` for adding [ECS Error fields](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)
+  for a given `Error` object.
+  ([#42](https://github.com/elastic/ecs-logging-js/pull/42))
+
 ## v0.5.0
 
 - Add [service.name](https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-name)

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -8,13 +8,15 @@ A set of helpers for the ECS logging libraries.
 You should not directly used this package, but the ECS logging libraries instead.
 
 ## Install
+
 ```sh
-npm i @elastic/ecs-helpers
+npm install @elastic/ecs-helpers
 ```
 
 ## API
 
 ### `version`
+
 The currently supported version of [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html).
 
 ### `stringify`
@@ -44,7 +46,48 @@ of objects with circular references. This generally means that ecs-logging-js
 libraries will throw a "Converting circular structure to JSON" exception if an
 attempt is made to log an object with circular references.
 
+### `formatError`
+
+A function that adds [ECS Error fields](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)
+for a given `Error` object.
+
+```js
+const { formatError } = require('@elastic/ecs-helpers')
+const logRecord = { msg: 'oops', /* ... */ }
+formatError(logRecord, new Error('boom'))
+console.log(logRecord)
+```
+
+will show:
+
+```js
+{
+  msg: 'oops',
+  error: {
+    type: 'Error',
+    message: 'boom',
+    stack_trace: 'Error: boom\n' +
+      '    at REPL30:1:26\n' +
+      '    at Script.runInThisContext (vm.js:133:18)\n' +
+      '    at REPLServer.defaultEval (repl.js:484:29)\n' +
+      '    at bound (domain.js:413:15)\n' +
+      '    at REPLServer.runBound [as eval] (domain.js:424:12)\n' +
+      '    at REPLServer.onLine (repl.js:817:10)\n' +
+      '    at REPLServer.emit (events.js:327:22)\n' +
+      '    at REPLServer.EventEmitter.emit (domain.js:467:12)\n' +
+      '    at REPLServer.Interface._onLine (readline.js:337:10)\n' +
+      '    at REPLServer.Interface._line (readline.js:666:8)'
+  }
+}
+```
+
+The ECS logging libraries typically use this to automatically handle an `err`
+metadata field passed to a logging statement. E.g.
+`log.warn({err: myErr}, '...')` for pino, `log.warn('...', {err: myErr})`
+for winston.
+
 ### `formatHttpRequest`
+
 Function that enhances an ECS object with http request data.
 The request object should be Node.js's core request object.
 
@@ -67,6 +110,7 @@ console.log(ecs)
 ```
 
 ### `formatHttpResponse`
+
 Function that enhances an ECS object with http response data.
 The response object should be Node.js's core response object.
 
@@ -89,4 +133,5 @@ console.log(ecs)
 ```
 
 ## License
+
 This software is licensed under the [Apache 2 license](./LICENSE).

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -69,14 +69,7 @@ will show:
     stack_trace: 'Error: boom\n' +
       '    at REPL30:1:26\n' +
       '    at Script.runInThisContext (vm.js:133:18)\n' +
-      '    at REPLServer.defaultEval (repl.js:484:29)\n' +
-      '    at bound (domain.js:413:15)\n' +
-      '    at REPLServer.runBound [as eval] (domain.js:424:12)\n' +
-      '    at REPLServer.onLine (repl.js:817:10)\n' +
-      '    at REPLServer.emit (events.js:327:22)\n' +
-      '    at REPLServer.EventEmitter.emit (domain.js:467:12)\n' +
-      '    at REPLServer.Interface._onLine (readline.js:337:10)\n' +
-      '    at REPLServer.Interface._line (readline.js:666:8)'
+      // ...
   }
 }
 ```

--- a/helpers/lib/error-formatters.js
+++ b/helpers/lib/error-formatters.js
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+'use strict'
+
+const { toString } = Object.prototype
+
+// Format an Error instance into ECS-compatible fields on the `ecs` object.
+// https://www.elastic.co/guide/en/ecs/current/ecs-error.html
+function formatError (ecsFields, err) {
+  if (!(err instanceof Error)) {
+    ecsFields.err = err
+    return
+  }
+
+  ecsFields.error = {
+    type: toString.call(err.constructor) === '[object Function]'
+      ? err.constructor.name
+      : err.name,
+    message: err.message,
+    stack_trace: err.stack
+  }
+}
+
+module.exports = { formatError }

--- a/helpers/lib/index.js
+++ b/helpers/lib/index.js
@@ -5,10 +5,12 @@
 'use strict'
 
 const stringify = require('./serializer')
+const errorFormatters = require('./error-formatters')
 const httpFormatters = require('./http-formatters')
 
 module.exports = {
   version: '1.5.0',
   stringify,
+  ...errorFormatters,
   ...httpFormatters
 }

--- a/helpers/lib/serializer.js
+++ b/helpers/lib/serializer.js
@@ -128,6 +128,16 @@ const stringify = build({
         name: string
       },
       additionalProperties: true
+    },
+    // https://www.elastic.co/guide/en/ecs/current/ecs-error.html
+    error: {
+      type: 'object',
+      properties: {
+        type: string,
+        message: string,
+        stack_trace: string
+      },
+      additionalProperties: true
     }
   },
   additionalProperties: true


### PR DESCRIPTION
This adds `formatError(ecsFields, err)` that will be used to add ECS Error fields (https://www.elastic.co/guide/en/ecs/current/ecs-error.html) to log records.